### PR TITLE
Request for comment on using RoadRenderer for diverging lanes

### DIFF
--- a/src/org/openstreetmap/josm/plugins/lanes/IntersectionRenderer.java
+++ b/src/org/openstreetmap/josm/plugins/lanes/IntersectionRenderer.java
@@ -470,6 +470,8 @@ public abstract class IntersectionRenderer {
 
     abstract LatLon getPos();
 
+    abstract RightOfWay getRightOfWay();
+
     public Way glue(Way a, Way b, double extension) {
         // Glue first half of a to second half of b.  Split into halves at intersect.
         double[] distances = new double[2];

--- a/src/org/openstreetmap/josm/plugins/lanes/LaneMappingMode.java
+++ b/src/org/openstreetmap/josm/plugins/lanes/LaneMappingMode.java
@@ -273,12 +273,15 @@ public class LaneMappingMode extends MapMode implements MouseListener, MouseMoti
                 if (!handled.contains(n.getUniqueId())) {
                     handled.add(n.getUniqueId());
                     executor.execute(() -> {
-                        if (!Utils.nodeShouldBeIntersection(n, this)) return;
+                        Utils.WayConnectionType type = Utils.calculateNodeIntersectionType(n, this);
+                        if (type != null && type != Utils.WayConnectionType.INCOMPLETE && type != Utils.WayConnectionType.CONTINUATION) System.out.println("Node " + n.getId() + " is " + type);
+                        if (type == Utils.WayConnectionType.INTERSECTION) {
 //                        try {
                             NodeIntersectionRenderer newest = new NodeIntersectionRenderer(n, mv, this);
                             intersections.add(newest);
                             nodeIdToISR.put(n.getUniqueId(), newest);
 //                        } catch (Exception ignored) {}
+                        }
                     });
                 }
             }

--- a/src/org/openstreetmap/josm/plugins/lanes/MarkedRoadRenderer.java
+++ b/src/org/openstreetmap/josm/plugins/lanes/MarkedRoadRenderer.java
@@ -242,28 +242,35 @@ public class MarkedRoadRenderer extends RoadRenderer {
         _offsetToLeftEnd -= placementDiff;
     }
 
+
     private double getPlacementAt(boolean start, boolean ignoreWidthTags) {
+        return getPlacementDistance(start, getPlacementTag(start), ignoreWidthTags);
+    }
+
+    /** Calculates the offset from this road's way to the position specified by otherPlacement. */
+    public double getPlacementOffsetFrom(String otherPlacement, int node) {
+        boolean start = node == 0; // TODO support nodes in the middle of the way.
+        return getPlacementAt(start, false) - getPlacementDistance(start, otherPlacement, false);
+    }
+
+    private double getPlacementDistance(boolean start, String placement, boolean ignoreWidthTags) {
         try {
-            // Get string representation of placement.
-            String placement = getPlacementTag(start);
-            int direction = placement.charAt(placement.length()-1) == 'f' ? 1 : placement.charAt(placement.length()-1) == 'b' ? -1 : 0;
-            placement = placement.substring(0, placement.length()-1);
+            int direction = placement.charAt(placement.length() - 1) == 'f' ? 1 : placement.charAt(placement.length() - 1) == 'b' ? -1 : 0;
+            placement = placement.substring(0, placement.length() - 1);
+            int lane = Integer.parseInt(placement.split(":")[1]);
 
-            String placementOther = getPlacementTag(!start);
-            int directionOther = -2;
-            if (placementOther != null) {
-                directionOther = placementOther.charAt(placementOther.length()-1) == 'f' ? 1 :
-                        placementOther.charAt(placementOther.length()-1) == 'b' ? -1 : 0;
-                placementOther = placementOther.substring(0, placementOther.length()-1);
-            }
+//        int directionOther = -2;
+//        if (placementOther != null) {
+//            directionOther = placementOther.charAt(placementOther.length()-1) == 'f' ? 1 :
+//                    placementOther.charAt(placementOther.length()-1) == 'b' ? -1 : 0;
+//            placementOther = placementOther.substring(0, placementOther.length()-1);
+//        }
 
-
+//        int laneOther = Integer.MIN_VALUE;
+//        if (placementOther != null) Integer.parseInt(placementOther.split(":")[1]); // ?? isn't this a no-op?
 
             // Get offset
             List<RoadPiece> pieces = getRoadPieces(false);
-            int lane = Integer.parseInt(placement.split(":")[1]);
-            int laneOther = Integer.MIN_VALUE;
-            if (placementOther != null) Integer.parseInt(placementOther.split(":")[1]);
             double offsetSoFar = 0;
             boolean valid = false;
 
@@ -282,13 +289,13 @@ public class MarkedRoadRenderer extends RoadRenderer {
                 RoadPiece p = pieces.get(i);
 
                 boolean correctLane = p._position+1 == lane && p._direction == direction && (p._direction == 0 || p instanceof Lane);
-                boolean correctLaneOther = false;
-                if (placementOther != null) correctLaneOther = p._position+1 == laneOther && p._direction == directionOther && (p._direction == 0 || p instanceof Lane);
+//                boolean correctLaneOther = false;
+//                if (placementOther != null) correctLaneOther = p._position+1 == laneOther && p._direction == directionOther && (p._direction == 0 || p instanceof Lane);
 
-                offsetSoFar += (ignoreWidthTags && !correctLane && !correctLaneOther) ? (pieces.get(i-1) instanceof Lane ? (Utils.
+                offsetSoFar += (ignoreWidthTags && !correctLane /*&& !correctLaneOther*/) ? (pieces.get(i-1) instanceof Lane ? (Utils.
                         WIDTH_LANES-Utils.RENDERING_WIDTH_DIVIDER) :
                         Utils.RENDERING_WIDTH_DIVIDER)/2 : (pieces.get(i-1).getWidth(start) / 2);
-                offsetSoFar += (ignoreWidthTags && !correctLane && !correctLaneOther) ? (p instanceof Lane ? (Utils.
+                offsetSoFar += (ignoreWidthTags && !correctLane /*&& !correctLaneOther*/) ? (p instanceof Lane ? (Utils.
                         WIDTH_LANES-Utils.RENDERING_WIDTH_DIVIDER) :
                         Utils.RENDERING_WIDTH_DIVIDER)/2 : (p.getWidth(start) / 2);
 
@@ -393,7 +400,7 @@ public class MarkedRoadRenderer extends RoadRenderer {
         }
     }
 
-    private String getPlacementTag(boolean start) {
+    public String getPlacementTag(boolean start) {
         String output = null;
         if (start && _way.hasTag("placement:start") && Utils.isOneway(_way)) {
             output = _way.get("placement:start") + "f";

--- a/src/org/openstreetmap/josm/plugins/lanes/MultiIntersectionRenderer.java
+++ b/src/org/openstreetmap/josm/plugins/lanes/MultiIntersectionRenderer.java
@@ -20,13 +20,17 @@ public class MultiIntersectionRenderer extends IntersectionRenderer {
     private List<NodeIntersectionRenderer> _space;
     private List<Long> _nodeIds;
     private LatLon _pos;
-
+    private RightOfWay _rightOfWay;
 
     public MultiIntersectionRenderer(List<NodeIntersectionRenderer> nodeOnlyIntersections, List<IntersectionRenderer> addToThis) {
         super(nodeOnlyIntersections.get(0)._mv, nodeOnlyIntersections.get(0)._m);
         // Fixme remove
         _ordering = new ArrayList<>();
         _vertextOrdering = new ArrayList<>();
+
+        if (nodeOnlyIntersections.size() == 1) {
+            _rightOfWay = nodeOnlyIntersections.get(0).getRightOfWay();
+        }
 
         _internalGraph = new ArrayList<>();
         _wayVectors = new ArrayList<>();
@@ -188,6 +192,11 @@ public class MultiIntersectionRenderer extends IntersectionRenderer {
     @Override
     public LatLon getPos() {
         return _pos;
+    }
+
+    @Override
+    RightOfWay getRightOfWay() {
+        return _rightOfWay;
     }
 
     public List<NodeIntersectionRenderer> getNodeOnlyIntersections() {

--- a/src/org/openstreetmap/josm/plugins/lanes/NodeIntersectionRenderer.java
+++ b/src/org/openstreetmap/josm/plugins/lanes/NodeIntersectionRenderer.java
@@ -23,6 +23,7 @@ public class NodeIntersectionRenderer extends IntersectionRenderer {
     // <editor-fold defaultstate="collapsed" desc="Variables"
 
     private Node _node;
+    private RightOfWay _rightOfWay;
 
     // </editor-fold>
 
@@ -32,6 +33,7 @@ public class NodeIntersectionRenderer extends IntersectionRenderer {
         super(mv, m);
         _node = n;
         _trimWays = false; // Only multi intersections do this.
+        _rightOfWay = RightOfWay.create(n, m);
         createIntersectionLayout();
     }
 
@@ -52,6 +54,11 @@ public class NodeIntersectionRenderer extends IntersectionRenderer {
     @Override
     public LatLon getPos() {
         return _node.getCoor();
+    }
+
+    @Override
+    public RightOfWay getRightOfWay() {
+        return _rightOfWay;
     }
 
     public Way getOutline() {

--- a/src/org/openstreetmap/josm/plugins/lanes/RightOfWay.java
+++ b/src/org/openstreetmap/josm/plugins/lanes/RightOfWay.java
@@ -1,5 +1,207 @@
 package org.openstreetmap.josm.plugins.lanes;
 
+import org.openstreetmap.josm.data.osm.Node;
+import org.openstreetmap.josm.data.osm.Way;
+import org.openstreetmap.josm.tools.Pair;
+
+import java.util.*;
+
+/**
+ * Represents the right of way through an "intersection". That is, non-intersecting flows of traffic that always have
+ * right of way over other traffic. Lane markings are expected to continue unbroken through the right of way.
+ *
+ * Currently only supports
+ * - one-way roads that fork (from 1 way into many) or merges (from many ways into 1), or
+ * - two-way roads that fork into one-way ways (where a dividing barrier starts),
+ * but could include a + intersection with stop or give way signs on two opposite roads, and the like.
+ */
+class RightOfWay {
+    public Node _node;
+
+    /** Inward pointing vector of the road that determines the position of the other lanes. */
+    public final WayVector mainRoad;
+
+    /** Maps directed lanes on the main road to matching directed lanes of outward pointing connected way vectors. */
+    public final Map<Integer, LaneRef> innerLaneToConnectedLane = new HashMap<>();
+
+    public RightOfWay(WayVector mainRoadInward) {
+        this._node = mainRoadInward.getParent().getNode(mainRoadInward.getTo());
+        this.mainRoad = mainRoadInward;
+    }
+
+    public void addConnectedWay(WayVector connectedRoadOutward, int innermostMainRoadDirectedLane) {
+        innerLaneToConnectedLane.put(innermostMainRoadDirectedLane, new LaneRef(connectedRoadOutward, connectedRoadOutward.isForward() ? 1 : -1));
+    }
+
+    /** Get the innermost matching lanes, first on the main road, second on the provided road. */
+    public Pair<LaneRef, LaneRef> getWayConnection(WayVector wayVec) {
+        for (int mainLane : innerLaneToConnectedLane.keySet()) {
+            LaneRef connectedLane = innerLaneToConnectedLane.get(mainLane);
+            if (connectedLane.wayVec.equals(wayVec)) {
+                return new Pair<>(new LaneRef(mainRoad,  mainLane), connectedLane);
+            }
+        }
+        return null;
+    }
+
+    /** Get the lane that matches the provided lane. */
+    public LaneRef getConnection(LaneRef laneRef) {
+        if (laneRef.wayVec.equals(mainRoad)) {
+            if (laneRef.directedLane == 0) return innerLaneToConnectedLane.get(0);
+            // Currently assuming no lane merges and only storing the innermost lane of each connected way.
+            else for (int l = laneRef.directedLane; l != 0; l -= Integer.signum(laneRef.directedLane)) {
+                if (innerLaneToConnectedLane.containsKey(l)) {
+                    return innerLaneToConnectedLane.get(l).getAdjacent(laneRef.directedLane - l);
+                }
+            }
+            return null;
+        }
+
+        else for (int mainLane : innerLaneToConnectedLane.keySet()) {
+            LaneRef connected = innerLaneToConnectedLane.get(mainLane);
+            if (connected.wayVec.equals(laneRef.wayVec)) {
+                return new LaneRef(mainRoad,  mainLane + (laneRef.directedLane - connected.directedLane));
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Calculate right of way for a single node intersection.
+     *
+     * Currently only supports points where the number of lanes remains the same but they diverge on one side.th
+     */
+    static RightOfWay create(Node node, LaneMappingMode m) {
+        try {
+            List<WayVector> wayVectors = Utils.getWaysFromNode(node, m);
+
+            // Count lanes to determine if this is a basic lane divergence.
+            // TODO: Check connectivity relations if they are present.
+            List<Integer> inWays = new ArrayList<>();
+            List<Integer> outWays = new ArrayList<>();
+            List<Integer> inOutWays = new ArrayList<>();
+            int inLanes = 0;
+            int outLanes = 0;
+            for (int i = 0; i < wayVectors.size(); i++) {
+                WayVector wv = wayVectors.get(i);
+                Way w = wv.getParent();
+                MarkedRoadRenderer mrr = (MarkedRoadRenderer) m.wayIdToRSR.get(w.getUniqueId());
+                if (mrr.getLaneCount(0) != 0) return null; // Don't support both way lanes
+                int in = mrr.getLaneCount(wv.isForward() ? -1 : 1);
+                int out = mrr.getLaneCount(wv.isForward() ? 1 : -1);
+                if (in > 0 && out > 0) {
+                    inOutWays.add(i);
+                } else if (in > 0) {
+                    inWays.add(i);
+                    inLanes += in;
+                } else if (out > 0) {
+                    outWays.add(i);
+                    outLanes += out;
+                }
+            }
+            if (inLanes == 0 || outLanes == 0) return null;
+
+            if (inLanes == outLanes && inOutWays.size() == 0 && (inWays.size() == 1 || outWays.size() == 1)) {
+                // One way fork or merge.
+                int mainI;
+                List<Integer> divergingWays;
+                if (inWays.size() == 1) {
+                    mainI = inWays.get(0);
+                    divergingWays = outWays;
+                } else {
+                    mainI = outWays.get(0);
+                    divergingWays = inWays;
+                }
+
+                RightOfWay output = new RightOfWay(wayVectors.get(mainI).reverse());
+                int mainLanes = inLanes;
+
+                // Default connectivity: Allocate the diverged ways to lanes to those in the main road in clockwise order.
+                int lanesAllocated = 0;
+                for (int i = 1; i < wayVectors.size(); i++) {
+                    int j = (i + mainI) % wayVectors.size();
+                    if (divergingWays.contains(j)) {
+                        WayVector connectedWV = wayVectors.get(j);
+                        MarkedRoadRenderer connectedMRR = (MarkedRoadRenderer) m.wayIdToRSR.get(connectedWV.getParent().getUniqueId());
+                        int connectedLanes = connectedMRR.getLaneCount(1);
+                        int lane = lanesAllocated + 1;
+                        if (!Utils.isRightHand(connectedWV.getParent()) ^ !output.mainRoad.isForward()) {
+                            // Allocating lanes outside in.
+                            lane = mainLanes - lane + 1 - connectedLanes + 1;
+                        }
+                        output.addConnectedWay(connectedWV, lane * (output.mainRoad.isForward() ? 1 : -1));
+                        lanesAllocated += connectedLanes;
+                    }
+                }
+                if (lanesAllocated != inLanes) System.out.println("Mistake in associating 1-in-many-out lanes!");
+                return output;
+            }
+
+            // Same thing but with two way roads.
+            if (inOutWays.size() == 1) {
+                int mainI = inOutWays.get(0);
+                WayVector mainWv = wayVectors.get(mainI).reverse();
+                MarkedRoadRenderer mrr = (MarkedRoadRenderer) m.wayIdToRSR.get(mainWv.getParent().getUniqueId());
+
+                if (mrr.getLaneCount(mainWv.isForward() ? 1 : -1) != outLanes ||
+                        mrr.getLaneCount(mainWv.isForward() ? -1 : 1) != inLanes) {
+                    return null; // TODO support this case, because it is easy to allocate lanes starting at the center line.
+                }
+
+                RightOfWay output = new RightOfWay(mainWv);
+                boolean isRightHand = Utils.isRightHand(mainWv.getParent());
+                int leftHandLanes = isRightHand ? inLanes : outLanes;
+
+                // Default connectivity: Allocate the diverged ways to lanes to those in the main road in clockwise order.
+                int lanesAllocated = 0;
+                for (int i = 1; i < wayVectors.size(); i++) {
+                    int j = (i + mainI) % wayVectors.size();
+
+                    if (lanesAllocated < leftHandLanes) {
+                        WayVector connectedWv = wayVectors.get(j);
+                        MarkedRoadRenderer connectedMrr = (MarkedRoadRenderer) m.wayIdToRSR.get(connectedWv.getParent().getUniqueId());
+                        int connectedLaneDir = (isRightHand ? -1 : 1) * (connectedWv.isForward() ? 1 : -1);
+                        int connectedLanes = connectedMrr.getLaneCount(connectedLaneDir);
+
+                        // Allocating lanes outside in.
+                        int lane = lanesAllocated + 1;
+                        lane = leftHandLanes - lane + 1 - connectedLanes + 1;
+                        output.addConnectedWay(connectedWv, lane * (isRightHand ? -1 : 1));
+                        lanesAllocated += connectedLanes;
+
+                        if (connectedMrr.getLaneCount(-1 * connectedLaneDir) > 0) {
+                            // TODO these lanes can be allocated to the other direction. i--; continue;
+                            return null;
+                        }
+                    } else if (lanesAllocated >= leftHandLanes) {
+                        WayVector connectedWv = wayVectors.get(j);
+                        MarkedRoadRenderer connectedMrr = (MarkedRoadRenderer) m.wayIdToRSR.get(connectedWv.getParent().getUniqueId());
+                        int connectedLaneDir = (isRightHand ? -1 : 1) * (connectedWv.isForward() ? -1 : 1);
+                        int connectedLanes = connectedMrr.getLaneCount(connectedLaneDir);
+
+                        // Allocate lanes inside out.
+                        int lane = lanesAllocated - leftHandLanes + 1;
+                        output.addConnectedWay(connectedWv, lane * (isRightHand ? 1 : -1));
+                        lanesAllocated += connectedLanes;
+
+                        if (connectedMrr.getLaneCount(-1 * connectedLaneDir) > 0) {
+                            return null; // Found more left-hand lanes that don't match up.
+                        }
+                    }
+                }
+                // TODO check that the angle between the first in way and last out way is smaller than ~90 degrees so we can assume no connectivity between them.
+                if (lanesAllocated != inLanes + outLanes) System.out.println("Mistake in associating road split lanes!");
+                return output;
+            }
+
+            return null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}
+
 class LaneRef {
     public final WayVector wayVec;
     /** The lane counted from the middle of the road, forward lanes in the direction of the wayVec positive, backwards lanes negative. */

--- a/src/org/openstreetmap/josm/plugins/lanes/RightOfWay.java
+++ b/src/org/openstreetmap/josm/plugins/lanes/RightOfWay.java
@@ -1,0 +1,37 @@
+package org.openstreetmap.josm.plugins.lanes;
+
+class LaneRef {
+    public final WayVector wayVec;
+    /** The lane counted from the middle of the road, forward lanes in the direction of the wayVec positive, backwards lanes negative. */
+    public final int directedLane;
+
+    public LaneRef(WayVector wayVec, int directedLane) {
+        this.wayVec = wayVec;
+        this.directedLane = directedLane;
+    }
+
+    public LaneRef getInsideLane() {
+        return new LaneRef(wayVec, directedLane - Integer.signum(directedLane));
+    }
+    public LaneRef getOutsideLane() {
+        return new LaneRef(wayVec, directedLane + Integer.signum(directedLane));
+    }
+    public LaneRef getAdjacent(int offset) {
+        return new LaneRef(wayVec, directedLane + offset);
+    }
+
+    public boolean equals(LaneRef other) {
+        return wayVec.equals(other.wayVec) && directedLane == other.directedLane;
+    }
+
+    public boolean equals(Object other) {
+        if (this == other) return true;
+        if (!(other instanceof LaneRef)) return false;
+        return equals((LaneRef) other);
+    }
+
+    public String toString() {
+        return "Lane " + (directedLane >= 0 ? "+" : "") + directedLane + " looking " +
+                (wayVec.isForward() ? "forward" : "backwards") + " along Way " + wayVec.getParent().getUniqueId();
+    }
+}


### PR DESCRIPTION
In this PR I have a proof of concept implementation of customised rendering of intersections with continuous lane markings through them. The implementation works for left hand roads that split (which aren't considered intersections at all).

The commits messages step through the different components.

[Here is](https://github.com/BjornRasmussen/Lanes/files/6952542/LaneDevTest.zip) a simple `.osm` file with some test intersections that are supported.

This image show the (a) ground truth, (b) naive lane estimation, (c) existing intersection rendering and, (d) this implementation:
![LanesShowcase](https://user-images.githubusercontent.com/3784591/128810723-207a3c65-8c46-4891-a34c-57864359b603.png)

---

I am interested in comments on how this approach fits in with your idea of architecture, and what you would want in order to merge this feature.

- Creating ways during intersection layout to represent the flows of traffic seems to work well. I think a hybrid approach would be ideal, with the geometry of the created ways influencing, but not replacing, the intersection area geometry, and a `RoadRenderer` that renders the lane markings only.
- I'm not sure if `RightOfWay` is being calculated at the right time and how it should fit into the optimised updating like `updateOneRoad`. My idea for the ideal calculation algorithm does generalise to multi-node intersections, so making it part of the intersection renderers seems to make sense.
- I don't know if the "Directed Lane" abstraction is necessary (I haven't even followed through on checking that right hand roads are properly rendered yet). I created it while trying to wrap my head around all this, but maybe it would be simpler to unroll it and just use native lane numbers.